### PR TITLE
Added handling for non-cli CLI arguments

### DIFF
--- a/tasks/cucumber.js
+++ b/tasks/cucumber.js
@@ -9,6 +9,12 @@
 'use strict';
 module.exports = function(grunt) {
     grunt.registerMultiTask('cucumberjs', 'Run cucumber.js features', function() {
+
+        var runtimeArgs = require('../../../features/config/personal.json');
+        grunt.option('features', runtimeArgs.features);
+        grunt.option('format', runtimeArgs.format);
+        grunt.option('tags', runtimeArgs.tags);
+        
         var done = this.async();
 
         var options = this.options({


### PR DESCRIPTION
I'm not entirely sure how the tags line will work since I never use them in my personal tests. Please advise.

Otherwise, the added lines still give preference to true CLI arguments, which is what we want.